### PR TITLE
feat: Add mock/debug infrastructure with BuildConfig flags

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,9 +20,21 @@ android {
     }
 
     buildTypes {
+        debug {
+            // Mock mode enabled for development - bypasses authentication and subscription
+            buildConfigField "boolean", "MOCK_AUTH", "true"
+            buildConfigField "boolean", "MOCK_SUBSCRIPTION", "true"
+            buildConfigField "String", "BUILD_TYPE_NAME", '"Debug"'
+        }
+
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+
+            // Production mode - uses real Google Sign-In and Billing
+            buildConfigField "boolean", "MOCK_AUTH", "false"
+            buildConfigField "boolean", "MOCK_SUBSCRIPTION", "false"
+            buildConfigField "String", "BUILD_TYPE_NAME", '"Release"'
         }
     }
     
@@ -38,6 +50,7 @@ android {
     
     buildFeatures {
         viewBinding true
+        buildConfig true
     }
 }
 

--- a/app/src/main/java/com/expensemanager/app/core/DebugConfig.kt
+++ b/app/src/main/java/com/expensemanager/app/core/DebugConfig.kt
@@ -1,0 +1,85 @@
+package com.expensemanager.app.core
+
+import com.expensemanager.app.BuildConfig
+import timber.log.Timber
+
+/**
+ * Centralized debug configuration for the app.
+ * Controls mock behavior for authentication and subscription in debug builds.
+ */
+object DebugConfig {
+
+    private const val TAG = "DebugConfig"
+
+    /**
+     * Whether to use mock authentication (bypasses Google Sign-In)
+     */
+    val useMockAuth: Boolean
+        get() = BuildConfig.MOCK_AUTH
+
+    /**
+     * Whether to use mock subscription (bypasses Google Play Billing)
+     */
+    val useMockSubscription: Boolean
+        get() = BuildConfig.MOCK_SUBSCRIPTION
+
+    /**
+     * Whether the app is running in debug mode
+     */
+    val isDebugBuild: Boolean
+        get() = BuildConfig.DEBUG
+
+    /**
+     * Build type name for logging
+     */
+    val buildTypeName: String
+        get() = BuildConfig.BUILD_TYPE_NAME
+
+    /**
+     * Initialize debug configuration and log current mode
+     * Should be called in Application.onCreate()
+     */
+    fun initialize() {
+        Timber.tag(TAG).i("═══════════════════════════════════════")
+        Timber.tag(TAG).i("🛠️  Debug Configuration Initialized")
+        Timber.tag(TAG).i("═══════════════════════════════════════")
+        Timber.tag(TAG).i("Build Type: $buildTypeName")
+        Timber.tag(TAG).i("Debug Build: $isDebugBuild")
+        Timber.tag(TAG).i("Mock Auth: ${if (useMockAuth) "✅ ENABLED" else "❌ DISABLED"}")
+        Timber.tag(TAG).i("Mock Subscription: ${if (useMockSubscription) "✅ ENABLED" else "❌ DISABLED"}")
+
+        if (useMockAuth || useMockSubscription) {
+            Timber.tag(TAG).w("⚠️  RUNNING IN MOCK MODE - NOT FOR PRODUCTION USE")
+        } else {
+            Timber.tag(TAG).i("✅ Production mode - using real Google services")
+        }
+        Timber.tag(TAG).i("═══════════════════════════════════════")
+    }
+
+    /**
+     * Get debug banner text for UI display
+     */
+    fun getDebugBanner(): String? {
+        return if (isDebugBuild && (useMockAuth || useMockSubscription)) {
+            "🛠️ DEBUG MODE"
+        } else {
+            null
+        }
+    }
+
+    /**
+     * Log when mock implementation is being used
+     */
+    fun logMockUsage(feature: String, reason: String) {
+        if (isDebugBuild) {
+            Timber.tag(TAG).d("🎭 Using MOCK $feature: $reason")
+        }
+    }
+
+    /**
+     * Log when real implementation is being used
+     */
+    fun logRealUsage(feature: String, reason: String) {
+        Timber.tag(TAG).d("🔐 Using REAL $feature: $reason")
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,14 @@
     <string name="permission_notification_denied_title">Notifications Disabled</string>
     <string name="permission_notification_denied_message">You won\'t receive push notifications for new transactions. You can enable them later in Settings > Apps > Smart Expense Manager > Permissions.</string>
     
+    <!-- Debug Mode -->
+    <string name="debug_banner">🛠️ DEBUG MODE</string>
+    <string name="debug_mode_enabled">Running in debug mode with mock services</string>
+    <string name="mock_auth_active">Mock authentication active</string>
+    <string name="mock_subscription_active">Mock subscription active (Premium)</string>
+    <string name="debug_user_name">Debug User</string>
+    <string name="debug_user_email">debug@expensemanager.dev</string>
+
     <!-- Common -->
     <string name="currency_symbol">₹</string>
     <string name="loading">Loading...</string>


### PR DESCRIPTION
Implements foundation for mock authentication and subscription in debug builds.

Features:
- BuildConfig flags: MOCK_AUTH, MOCK_SUBSCRIPTION, BUILD_TYPE_NAME
- Debug builds automatically use mock implementations
- Release builds use real Google Sign-In and Billing
- DebugConfig.kt: Centralized debug configuration with Timber logging
- Debug mode strings for UI indicators

Technical Details:
- buildConfig feature enabled in build.gradle
- Debug variant: MOCK_AUTH=true, MOCK_SUBSCRIPTION=true
- Release variant: MOCK_AUTH=false, MOCK_SUBSCRIPTION=false
- DebugConfig.initialize() logs build mode on app start

This establishes the infrastructure for feature branches:
- feature/google-signin (will use BuildConfig.MOCK_AUTH)
- feature/google-play-billing (will use BuildConfig.MOCK_SUBSCRIPTION)

🤖 Generated with Claude Code